### PR TITLE
/data command

### DIFF
--- a/grammars/mcfunction13.json
+++ b/grammars/mcfunction13.json
@@ -48,7 +48,7 @@
 			"include": "#nbt-compound"
 		},
 		{
-			"match": "(?:^|(?<=run ))(?:advancement|clear|clone|data|defaultgamemode|difficulty|effect|execute|fill|function|gamemode|gamerule|give|kill|locate|msg|particle|playsound|recipe|reload|replaceitem|say|scoreboard|tag|teams|seed|setblock|setworldspawn|spreadplayers|stopsound|summon|teleport|tellraw|tell|time|title|tp|trigger|w|weather|worldborder|xp)\\b",
+			"match": "(?:^|(?<=run ))(?:advancement|clear|clone|data|defaultgamemode|difficulty|effect|execute|experience|fill|function|gamemode|gamerule|give|kill|locate|msg|particle|playsound|recipe|reload|replaceitem|say|scoreboard|tag|teams|seed|setblock|setworldspawn|spreadplayers|stopsound|summon|teleport|tellraw|tell|time|title|tp|trigger|w|weather|worldborder|xp)\\b",
 			"name": "command"
 		},
 		{

--- a/grammars/mcfunction13.json
+++ b/grammars/mcfunction13.json
@@ -48,7 +48,7 @@
 			"include": "#nbt-compound"
 		},
 		{
-			"match": "(?:^|(?<=run ))(?:advancement|blockdata|clear|clone|defaultgamemode|detect|difficulty|effect|entitydata|execute|fill|function|gamemode|gamerule|give|kill|locate|msg|offset|particle|playsound|recipe|reload|replaceitem|say|scoreboard|tag|teams|seed|setblock|setworldspawn|spreadplayers|stopsound|summon|teleport|tellraw|tell|time|title|toggledownfall|tp|trigger|w|weather|worldborder|xp)\\b",
+			"match": "(?:^|(?<=run ))(?:advancement|clear|clone|data|defaultgamemode|difficulty|effect|execute|fill|function|gamemode|gamerule|give|kill|locate|msg|particle|playsound|recipe|reload|replaceitem|say|scoreboard|tag|teams|seed|setblock|setworldspawn|spreadplayers|stopsound|summon|teleport|tellraw|tell|time|title|tp|trigger|w|weather|worldborder|xp)\\b",
 			"name": "command"
 		},
 		{

--- a/lib/commands.json
+++ b/lib/commands.json
@@ -50,19 +50,6 @@
 				}
 			]
 		},
-		"blockdata": {
-			"name": "blockdata",
-			"cycleMarkers": [
-				{
-					"type": "coord",
-					"value": "pos"
-				},
-				{
-					"type": "nbt",
-					"value": "nbt"
-				}
-			]
-		},
 		"clear": {
 			"name": "clear",
 			"cycleMarkers": [
@@ -118,6 +105,114 @@
 						"move",
 						"normal"
 					]
+				}
+			]
+		},
+		"data": {
+			"name": "data",
+			"cycleMarkers": [
+				{
+					"type": "option",
+					"value": [
+						"get",
+						"merge",
+						"remove"
+					],
+					"change": {
+						"get": [
+							{
+								"type": "option",
+								"value": [
+									"block",
+									"entity"
+								],
+								"change": {
+									"block": [
+										{
+											"type": "coord",
+											"value": "x y z"
+										}
+									],
+									"entity": [
+										{
+											"type": "entity",
+											"value": "target"
+										}
+									]
+								}
+							},
+							{
+								"type": "string",
+								"value": "path",
+								"optional": true
+							},
+							{
+								"type": "string",
+								"value": "scale",
+								"optional": true
+							},
+							{
+								"type": "end"
+							}
+						],
+						"merge": [
+							{
+								"type": "option",
+								"value": [
+									"block",
+									"entity"
+								],
+								"change": {
+									"block": [
+										{
+											"type": "coord",
+											"value": "x y z"
+										}
+									],
+									"entity": [
+										{
+											"type": "entity",
+											"value": "target"
+										}
+									]
+								}
+							},
+							{
+								"type": "nbt",
+								"value": "nbt"
+							}
+						],
+						"remove": [
+							{
+								"type": "option",
+								"value": [
+									"block",
+									"entity"
+								],
+								"change": {
+									"block": [
+										{
+											"type": "coord",
+											"value": "x y z"
+										}
+									],
+									"entity": [
+										{
+											"type": "entity",
+											"value": "target"
+										}
+									]
+								}
+							},
+							{
+								"type": "string",
+								"value": "path"
+							},
+							{
+								"type": "end"
+							}
+						]
+					}
 				}
 			]
 		},
@@ -189,19 +284,6 @@
 				{
 					"type": "boolean",
 					"value": "hideParticles"
-				}
-			]
-		},
-		"entitydata": {
-			"name": "entitydata",
-			"cycleMarkers": [
-				{
-					"type": "entity",
-					"value": "targets"
-				},
-				{
-					"type": "nbt",
-					"value": "nbt"
 				}
 			]
 		},
@@ -1285,10 +1367,6 @@
 					"value": "title"
 				}
 			]
-		},
-		"toggledownfall": {
-			"name": "toggledownfall",
-			"cycleMarkers": []
 		},
 		"trigger": {
 			"name": "trigger",


### PR DESCRIPTION
I added the new `/data` command and removed the old `/blockdata` and `/entitydata` commands. I also noticed some other old commands that were left in the `mcfunction13` grammar and I removed those as well.

I'm not very familiar with Atom packages, so I might not be using the most efficient way to achieve the `/data` command. Feel free to improve on it!

I've been using your package for a while now and I absolutely love it! Keep up the great work! 👍 